### PR TITLE
Expose underlying BSON types from MongoJS

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,3 +24,17 @@ module.exports = function (connString, cols, options) {
   })
   return db;
 };
+
+// expose bson stuff visible in the shell
+module.exports.Binary     = mongojs.Binary      ;
+module.exports.Code       = mongojs.Code        ;
+module.exports.DBRef      = mongojs.DBRef       ;
+module.exports.Double     = mongojs.Double      ;
+module.exports.Long       = mongojs.Long        ;
+module.exports.NumberLong = mongojs.NumberLong  ;
+module.exports.MinKey     = mongojs.MinKey      ;
+module.exports.MaxKey     = mongojs.MaxKey      ;
+module.exports.ObjectID   = mongojs.ObjectID    ;
+module.exports.ObjectId   = mongojs.ObjectId    ;
+module.exports.Symbol     = mongojs.Symbol      ;
+module.exports.Timestamp  = mongojs.Timestamp   ;


### PR DESCRIPTION
These are necessary if you want to do things like use literal ObjectIds in your code.

For example, this solution on StackOverflow is possible with MongoJS but not with then-mongo:
http://stackoverflow.com/questions/21076460/how-to-convert-a-string-to-objectid-in-nodejs-mongodb-native-driver

Implementation mostly lifted from MongoJS:
https://github.com/mafintosh/mongojs/blob/8e7ae24c3963d706c2b94f1778dcc0fcba2fbc99/index.js#L26-L38
